### PR TITLE
Rewrote h() function, potential 50x speedup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: binaryLogic
 Title: Binary Logic
 Description: Convert to binary numbers (Base2). Shift, rotate, summary. Based on logical vector.
-Version: 0.3.5
+Version: 0.3.6
 Author: Daniel Dörrhöfer <ddo@openmailbox.org>
 Maintainer: Daniel Dörrhöfer <ddo@openmailbox.org>
 URL: https://github.com/d4ndo/binaryLogic

--- a/R/BinaryS3.R
+++ b/R/BinaryS3.R
@@ -442,14 +442,22 @@ dec2bin <- function(num, signed=FALSE, littleEndian=FALSE, size=2, n=0) {
 
 # Helper function to convert decimal to binary
 h <- function(x) {
-    # v should be global.
-    v <- c(0,  2^(0:1016))
-    ret <- numeric(1)
-    for(i in 1:length(v)) {
-        if (v[i] > x) { ret <- c(i-1, h(x-v[i-1])); break }
-        if (v[i] == x) return(ret <- c(i, ret))
-    }
-    return(ret)
+    # Basic error handling: function expects single positive integer
+    if(x %% 1 != 0) { stop("Non-integer input to h()") }
+    if(x < 0) { stop("Negative input to h()") }
+
+    # Special case
+    if(x == 0) { return(c(1, 0)) }
+
+    # Only generate as many comparison digits as we need
+    num_digits = floor(log2(x)) + 1
+
+    # Get x %% each power of two; points in the vector where this
+    # changes are active. Because my function has bit order reversed
+    # versus the original h() function, we need to go num_digits -
+    # the active bits. The +2 and append 0 are to match the original
+    # h behavior
+    c(num_digits + 2 - which(diff(x %% 2^(num_digits:0)) != 0), 0)
 }
 
 # Helper function


### PR DESCRIPTION
I was writing some code for a different page to do decimal to binary-vector conversion. Upon checking if there were any existing packages that did so, I found yours. My needs were ultimately a little different than what your package supplied, but on finding the code, I located an opportunity for a speed increase.

I rewrote your `h()` function to take advantage of vector arithmetic and a different strategy for calculating which bits are live. I also bumped the version number to 0.3.6. This should be a drop-in change for your code and should not impact any other functions or CRAN submission.

Feel free to add me as "contributor" in the DESCRIPTION file if you feel that is appropriate -- if not, feel free to use the code without attribution. Use how you see fit.

As an attachment I've included a minimum working example to prove that a) the new code produces the same output for all integers from 0 to 100,000 and b) when running 100 jobs of 1,000 numbers sampled at random from tiny to enormous, the new code is on average 50 times faster on my computer. To read the output you'll want to check the "median" column of the microbenchmark output -- microbenchmark will default to 100 iterations, and each iteration will run the function for 1,000 numbers.

[test_new_h_function.R.zip](https://github.com/d4ndo/binaryLogic/files/1545321/test_new_h_function.R.zip)